### PR TITLE
fix: match return type of dingo

### DIFF
--- a/src/Serializers/ArraySerializer.php
+++ b/src/Serializers/ArraySerializer.php
@@ -19,9 +19,9 @@ class ArraySerializer extends BaseSerializer
     /**
      * Serialize null resource.
      *
-     * @return array
+     * @return array|null
      */
-    public function null()
+    public function null(): ?array
     {
         return null;
     }
@@ -33,7 +33,7 @@ class ArraySerializer extends BaseSerializer
      *
      * @return array
      */
-    public function paginator(PaginatorInterface $paginator)
+    public function paginator(PaginatorInterface $paginator): array
     {
         $currentPage = (int) $paginator->getCurrentPage();
         $lastPage = (int) $paginator->getLastPage();

--- a/src/Serializers/DataArraySerializer.php
+++ b/src/Serializers/DataArraySerializer.php
@@ -19,21 +19,21 @@ class DataArraySerializer extends BaseSerializer
     /**
      * Serialize null resource.
      *
-     * @return array
+     * @return array|null
      */
-    public function null()
+    public function null(): ?array
     {
         return ['data' => null];
     }
 
-        /**
+    /**
      * Serialize the paginator.
      *
      * @param PaginatorInterface $paginator
      *
      * @return array
      */
-    public function paginator(PaginatorInterface $paginator)
+    public function paginator(PaginatorInterface $paginator): array
     {
         $currentPage = (int) $paginator->getCurrentPage();
         $lastPage = (int) $paginator->getLastPage();


### PR DESCRIPTION
修复在 PHP 8.1 下, 与 dingo 父方法返回值类型不统一会报错的问题